### PR TITLE
Add a function as a configuration option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
+config :aloha, :hello, fn -> :world end
+
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment
 # by uncommenting the line below and defining dev.exs, test.exs and such.

--- a/lib/aloha.ex
+++ b/lib/aloha.ex
@@ -13,6 +13,6 @@ defmodule Aloha do
 
   """
   def hello do
-    :world
+    Application.get_env(:aloha, :hello).()
   end
 end

--- a/release_log
+++ b/release_log
@@ -1,0 +1,6 @@
+[~/projects/elixir/aloha (function)]> ./_build/dev/rel/aloha/bin/aloha start
+could not start kernel pid (application_controller) (error in config file "/Users/ipriestley/projects/elixir/aloha/_build/dev/rel/aloha/var/sys.config" (4): syntax error before: Fun)
+
+Crash dump is being written to: erl_crash.dump...done
+{"could not start kernel pid",application_controller,"error in config file \"/Users/ipriestley/projects/elixir/aloha/_build/dev/rel/aloha/var/sys.config\" (4): syntax error before: Fun"}
+Unable to configure release!


### PR DESCRIPTION
For some reason, this works when run directly with `mix` but raises an error when compiled with distillery:

```
[~/projects/elixir/aloha (function)]> ./_build/dev/rel/aloha/bin/aloha start
could not start kernel pid (application_controller) (error in config file "/Users/ipriestley/projects/elixir/aloha/_build/dev/rel/aloha/var/sys.config" (4): syntax error before: Fun)

Crash dump is being written to: erl_crash.dump...done
{"could not start kernel pid",application_controller,"error in config file \"/Users/ipriestley/projects/elixir/aloha/_build/dev/rel/aloha/var/sys.config\" (4): syntax error before: Fun"}
Unable to configure release!
```